### PR TITLE
Slightly smarter logic to find the MTGA install location.

### DIFF
--- a/source/mtga/set_data/dynamic.py
+++ b/source/mtga/set_data/dynamic.py
@@ -8,12 +8,22 @@ import re
 from mtga.models.card import Card
 from mtga.models.card_set import Set
 
+def _get_data_location():
+    root = os.environ.get(
+        "ProgramFiles(x86)",
+        os.environ.get(
+            "ProgramFiles",
+            r"C:\Program Files (x86)"
+        )
+    )
+    return os.path.join(root, "Wizards of the Coast", "MTGA", "MTGA_Data", "Downloads", "Data")
+
 COLOR_ID_MAP = {1: "W", 2: "U", 3: "B", 4: "R", 5: "G"}
 RARITY_ID_MAP = {0: "Token", 1: "Basic", 2: "Common", 3: "Uncommon", 4: "Rare", 5: "Mythic Rare"}
 
 dynamic_set_tuples = []
 
-data_location = r"C:\Program Files (x86)\Wizards of the Coast\MTGA\MTGA_Data\Downloads\Data"
+data_location = _get_data_location()
 
 json_filepaths = {"enums": "", "cards": "", "abilities": "", "loc": ""}
 


### PR DESCRIPTION
First of all, big thanks for the dynamic card finder, I've been missing my ELD cards :-)

That said, I can think of two scenarios in which the hardcoded `C:\Program Files (x86)\Wizards of the Coast\MTGA\MTGA_Data\Downloads\Data` isn't correct:

1. (Untested) It is possible to change the default install location in Windows, often done to install things other than on the C: drive. I have no idea if the MTGA installer honours this, but it's in theory possible.
2. There's no guarantee that the Python is being run under Windows. This is actually my use case in that I do my Python dev work in either Windows Subsystem for Linux or dual booted. The MTGA files are accessible in both cases but just not at `C:\...`.

This change (tested under Windows 10, WSL/Ubuntu and native boot Debian) allows at least a small amount of configuration for the location of the MTGA files. It does "the right thing" on Windows when the `ProgramFiles(x86)` environment variable exists, falling back to `ProgramFiles` if that doesn't exist, and allows bodging it a bit by explicitly setting `ProgramFiles` in the other environments.

Technically, I _think_ the fallback from `ProgramFiles(x86)` to `ProgramFiles` isn't necessary here as MTGA requires a 64-bit Windows install and that means that `ProgramFiles(x86)` will always be set... but it's impossible to set an environment variable with parentheses in the name on a Unix-ish OS so it's handy to have anyway.

If you think there's a better way of allowing the MTGA install location to be specified, feel free to ignore this patch and do that instead - in the longer term, there will probably be a need to support the upcoming macOS version as well.