### PR TITLE
Better method for finding new language key

### DIFF
--- a/source/mtga/set_data/dynamic.py
+++ b/source/mtga/set_data/dynamic.py
@@ -63,11 +63,8 @@ for set_name in listed_cardsets:
     all_abilities = {}
 
     loc_map = {}
-    try:
-        en = list(filter(lambda x: x["langkey"] == "EN", loc))[0]
-    except:
-        ## langkeys are null in 11/21 patch???
-        en = loc[0]
+    # Post 2019-11-21 patch, language is encoded in a different key
+    en = list(filter(lambda x: x["langkey"] == "EN" or x["isoCode"] == "en-US", loc))[0]
     for obj in en["keys"]:
         # if obj["id"] in loc_map.keys():
         #     print("WARNING: overwriting id {} = {} with {}".format(obj["id"], loc_map[obj["id"]], obj["text"]))


### PR DESCRIPTION
A slightly nicer method for finding the English localizations in the latest patch - Arena has moved the value we're looking for from the `langkey` field to the `isoCode` field, I'm guessing to allow for (e.g.) different US English vs British English translations in future.

If we're not bothered about backwards compatibility, we could just drop the `langkey` check. I really doubt many people run the latest Python on an older Arena install but you never know...